### PR TITLE
fix: syntax error for generated types with additional properties

### DIFF
--- a/lib/builder/type-builder.ts
+++ b/lib/builder/type-builder.ts
@@ -165,6 +165,7 @@ function generateCodeForProperty(
     // If there are already properties, we need to concatenate the additional
     // properties Record with existing
     if (hasProperties) {
+      propertiesTypeString += indented('}', level);
       return `${indentedPropertyPrefix}${wrapNullable(propertiesTypeString, nullable)} & ${additionalPropertiesTypeString}`;
     }
     return indented(


### PR DESCRIPTION
- add closing bracket for additional properties and other properties
- another commit for squash
