### PR TITLE
fix: use trusted publishing for npm releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -24,6 +25,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: ${{ steps.publish.outputs.release_created }}
@@ -33,9 +36,10 @@ jobs:
         if: ${{ steps.publish.outputs.release_created }}
         run: npm run build
 
+      - name: Run Tests
+        if: ${{ steps.publish.outputs.release_created }}
+        run: npm test
+
       - name: Publish to NPM
         if: ${{ steps.publish.outputs.release_created }}
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc && npm publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
+        run: npm publish

--- a/bin/ott.js
+++ b/bin/ott.js
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+
+require('../dist/main.js');

--- a/package.json
+++ b/package.json
@@ -17,15 +17,16 @@
   ],
   "main": "./dist/main.js",
   "bin": {
-    "ott": "./dist/main.js"
+    "ott": "bin/ott.js"
   },
   "files": [
+    "bin",
     "dist",
     "CHANGELOG.md"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pablaber/openapi-typescript-types/"
+    "url": "git+https://github.com/pablaber/openapi-typescript-types.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Switch release publishing from `NPM_TOKEN` to npm trusted publishing/OIDC in `release.yaml`.
- Add npm registry setup, disable release-build package-manager cache, and run tests before publishing.
- Add a tracked `ott` bin shim and normalize package repository metadata so npm package validation passes before `dist` exists.

## Validation

- `rm -rf dist test/output && npm run lint && npm run build && npm test && npm publish --dry-run` — clean.
